### PR TITLE
Run cicd on tmp branch push

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,7 +5,7 @@ name: CI/CD
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "gh-readonly-queue/{base_branch}/*"]
   pull_request:
     branches: ["master"]
   merge_group:


### PR DESCRIPTION
Trying to debug why cicd isn't running when `github-actions` requests a merge.

CICD should be requested from the `merge_groups` `on:` stanza, but this also adds the temporary branch that merge queues use.