### PR TITLE
remove push on tmp branch build trigger

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,7 +5,7 @@ name: CI/CD
 
 on:
   push:
-    branches: ["master", "gh-readonly-queue/{base_branch}/*"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
   merge_group:


### PR DESCRIPTION
Backs out the change in #787 . The `merge_group` trigger should be sufficient as long as the build isn't triggered by an action that uses `GITHUB_TOKEN`.